### PR TITLE
stop cookie name growing each time session is saved

### DIFF
--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -28,6 +28,8 @@ class RedisStorage(AbstractStorage):
             with (yield from self._redis) as conn:
                 key = str(cookie)
                 data = yield from conn.get(cookie)
+                if not data:
+                    return Session(None, new=True)
                 data = data.decode('utf-8')
                 data = self._decoder(data)
                 return Session(key, data=data, new=False)

--- a/aiohttp_session/redis_storage.py
+++ b/aiohttp_session/redis_storage.py
@@ -26,7 +26,7 @@ class RedisStorage(AbstractStorage):
             return Session(None, new=True)
         else:
             with (yield from self._redis) as conn:
-                key = self.cookie_name + '_' + str(cookie)
+                key = str(cookie)
                 data = yield from conn.get(cookie)
                 data = data.decode('utf-8')
                 data = self._decoder(data)


### PR DESCRIPTION
I think this is a mistake: I end up with a longer key (one more 'cookie name' prefix) when I call get_session and this gets persisted to the browser if the session is saved

Also, I want to handle the case where the session in redis expires but the cookie is still present in the user's browser.