### PR TITLE
Updated secret_key requirement in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ A trivial usage example::
 
     import asyncio
     import time
-    import os
+    import base64
+    from cryptorgraphy import fernet
     from aiohttp import web
     from aiohttp_session import setup, get_session, session_middleware
     from aiohttp_session.cookie_storage import EncryptedCookieStorage
@@ -38,7 +39,8 @@ A trivial usage example::
 
     app = web.Application()
     # secret_key must be 32 url-safe base64-encoded bytes
-    secret_key = os.urandom(32)
+    fernet_key = fernet.Fernet.generate_key()
+    secret_key = base64.urlsafe_b64decode(fernet_key)
     setup(app, EncryptedCookieStorage(secret_key))
     app.router.add_route('GET', '/', handler)
     web.run_app(app)

--- a/demo/main.py
+++ b/demo/main.py
@@ -1,0 +1,22 @@
+import asyncio
+import time
+import os
+from aiohttp import web
+from aiohttp_session import setup, get_session, session_middleware
+from aiohttp_session.cookie_storage import EncryptedCookieStorage
+
+@asyncio.coroutine
+def handler(request):
+    session = yield from get_session(request)
+    last_visit = session['last_visit'] if 'last_visit' in session else None
+    session['last_visit'] = time.time()
+    text = 'Last visited: {}'.format(last_visit)
+    return web.Response(body=text.encode('utf-8'))
+
+app = web.Application()
+# secret_key must be 32 url-safe base64-encoded bytes
+secret_key = os.urandom(32)
+setup(app, EncryptedCookieStorage(secret_key))
+app.router.add_route('GET', '/', handler)
+web.run_app(app)
+

--- a/demo/main.py
+++ b/demo/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
-import os
+import base64
+from cryptography import fernet
 from aiohttp import web
 from aiohttp_session import setup, get_session, session_middleware
 from aiohttp_session.cookie_storage import EncryptedCookieStorage
@@ -15,7 +16,8 @@ def handler(request):
 
 app = web.Application()
 # secret_key must be 32 url-safe base64-encoded bytes
-secret_key = os.urandom(32)
+fernet_key = fernet.Fernet.generate_key()
+secret_key = base64.urlsafe_b64decode(fernet_key)
 setup(app, EncryptedCookieStorage(secret_key))
 app.router.add_route('GET', '/', handler)
 web.run_app(app)


### PR DESCRIPTION
## What these changes does?

* secret_key must be 32 url-safe base64-encoded bytes instead of 16 bytes
* using web.run_app(app) to follow aiohttp demo example
* added demo code

## How to test your changes?

Run main.py in demo 

## Related issue number

#32 

## Checklist

- [ O ] Code is written and well
- [ X ] Tests for the changes are provided (not required)
- [ O ] Documentation reflects the changes