### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ aiohttp_session
 
 The library provides sessions for `aiohttp.web`__.
 
-.. _aiohttp_web: http://aiohttp.readthedocs.org/en/latest/web.html
+.. _aiohttp_web: https://aiohttp.readthedocs.io/en/latest/web.html
 
 __ aiohttp_web_
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -329,7 +329,7 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {'https://docs.python.org/3': None,
-                       'http://aiohttp.readthedocs.org/en/stable': None,
-                       'http://aioredis.readthedocs.org/en/latest': None,
+                       'https://aiohttp.readthedocs.io/en/stable': None,
+                       'https://aioredis.readthedocs.io/en/latest': None,
                        'http://cryptography.io/en/latest': None,
-                       'https://pynacl.readthedocs.org/en/latest': None}
+                       'https://pynacl.readthedocs.io/en/latest': None}

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -12,7 +12,7 @@
 
       :term:`asyncio` compatible Redis client library
 
-      http://aioredis.readthedocs.org/
+      https://aioredis.readthedocs.io/
 
    asyncio
 
@@ -35,7 +35,7 @@
 
       Yet another libary used for encrypting secure cookied session
 
-      https://pynacl.readthedocs.org
+      https://pynacl.readthedocs.io
 
    session
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.